### PR TITLE
Fixes typo in script tag usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var quill = new Quill(editor, {
     // ...
     modules: {
         // ...
-        ImageResize: {
+        imageResize: {
             // See optional "config" below
         }
     }


### PR DESCRIPTION
People who copy and paste the script tag example will get an error that reads "quill Cannot import modules/ImageResize. Are you sure it was registered?" because the module is uppercased in the example but lowercased in the code.